### PR TITLE
Add a feature to handle DialogFragment recreation

### DIFF
--- a/fragmentoperator/src/main/java/com/tubitv/fragmentoperator/FragmentOperator.kt
+++ b/fragmentoperator/src/main/java/com/tubitv/fragmentoperator/FragmentOperator.kt
@@ -248,6 +248,27 @@ object FragmentOperator {
         dialog.show(activity.supportFragmentManager, dialog.getDialogTag())
     }
 
+    /**
+     * Display the dialog for which you would like a result when it dismissed
+     * and adding the fragment to the activity supportFragmentManager.
+     *
+     * @param dialog FoDialog, want to display
+     * @param requestCode this code will be returned in {@link FoFragment#onDialogFragmentResult} when the dialog is dismissed.
+     */
+    fun showDialogFragmentForResult(dialog: FoDialog, requestCode: Int) {
+        val activity = getCurrentActivity() ?: return
+
+        var currentFragment =
+                getCurrentFragment(activity.supportFragmentManager, activity.getFragmentContainerResId()) ?: return
+
+        if (currentFragment is TabsNavigator) {
+            currentFragment = currentFragment.getCurrentContainerFragment()?.getCurrentChildFragment() ?: return
+        }
+        dialog.setTargetAndCode(currentFragment, requestCode)
+
+        showDialog(dialog)
+    }
+
     fun handlePendingChildFragments(containerFragment: FoFragment) {
         if (!mPendingChildFragmentList.isEmpty()) {
             for (fragment in mPendingChildFragmentList) {
@@ -381,6 +402,30 @@ object FragmentOperator {
         }
 
         return null
+    }
+
+    /**
+     * find a FoFragment by tag
+     *
+     * @param tag the fragment tag which is identified when inflated from XML or as supplied when added in a transaction.
+     * @return Can be null if no FoFragment is found.
+     */
+    fun findFoFragmentByTag(tag: String): FoFragment? {
+        val activity = getCurrentActivity() ?: return null
+
+        var targetFragment = activity.supportFragmentManager.findFragmentByTag(tag)
+        if (targetFragment != null) return targetFragment as? FoFragment
+
+        targetFragment =
+                getCurrentFragment(activity.supportFragmentManager, activity.getFragmentContainerResId()) ?: return null
+
+        if (targetFragment is TabsNavigator) {
+            val containerFragment = targetFragment.getCurrentContainerFragment() ?: return null
+            targetFragment = containerFragment.getHostFragmentManager().findFragmentByTag(tag)
+
+            return targetFragment as? FoFragment
+        }
+        return if ((targetFragment as? FoFragment)?.getFragmentTag() == tag) targetFragment else null
     }
 
     private fun getCurrentActivity(): FoActivity? {

--- a/fragmentoperator/src/main/java/com/tubitv/fragmentoperator/dialog/FoDialog.kt
+++ b/fragmentoperator/src/main/java/com/tubitv/fragmentoperator/dialog/FoDialog.kt
@@ -1,27 +1,42 @@
 package com.tubitv.fragmentoperator.dialog
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.support.v4.app.DialogFragment
+import com.tubitv.fragmentoperator.fragment.FoFragment
+import com.tubitv.fragments.FragmentOperator
 
 open class FoDialog : DialogFragment() {
     private val TAG = FoDialog::class.simpleName
 
+    private val TARGET_FRAGMENT_TAG = "target_fragment_tag"
+    private val REQUEST_CODE = "request_code"
     private val DIALOG_TAG = "dialog_tag"
     private val DIALOG_TAG_SEPERATOR = ":"
 
     private var mDialogTag: String? = null // Tag for current DialogFragment instance
+    private val mArguments: HashMap<String, Any> = hashMapOf()
+    private var mRequestCode: Int? = null
+    private var mResultCode: Int? = null
+    private var mTargetFragmentTag: String? = null
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
 
-        // Save previous fragment tag and current fragment tag, so we don't lose them during fragment recreation
+        // Save data, so we don't lose them during fragment recreation
         outState.putString(DIALOG_TAG, getDialogTag())
+        outState.putString(TARGET_FRAGMENT_TAG, mTargetFragmentTag)
+        mRequestCode?.let { outState.putInt(REQUEST_CODE, it) }
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
             mDialogTag = savedInstanceState.getString(DIALOG_TAG)
+            mTargetFragmentTag = savedInstanceState.getString(TARGET_FRAGMENT_TAG)
+            if (savedInstanceState.containsKey(REQUEST_CODE)) {
+                mRequestCode = savedInstanceState.getInt(REQUEST_CODE)
+            }
         }
     }
 
@@ -37,5 +52,45 @@ open class FoDialog : DialogFragment() {
             mDialogTag = this.javaClass.simpleName + DIALOG_TAG_SEPERATOR + this.hashCode()
         }
         return mDialogTag
+    }
+
+    /**
+     * Set result for {@link FoFragment#onDialogFragmentResult}
+     */
+    fun setResult(resultCode: Int) {
+        mResultCode = resultCode
+    }
+
+    /**
+     * Set result for {@link FoFragment#onDialogFragmentResult}
+     */
+    fun setResult(resultCode: Int, arguments: HashMap<String, Any>) {
+        mResultCode = resultCode
+        mArguments.putAll(arguments)
+    }
+
+    /**
+     * Get map to pass values to a Fragment.
+     */
+    fun getDataMap(): HashMap<String, Any> {
+        return mArguments
+    }
+
+    /**
+     * Set the target and request code.
+     */
+    fun setTargetAndCode(targetFragment: FoFragment, requestCode: Int) {
+        mTargetFragmentTag = targetFragment.getFragmentTag()
+        mRequestCode = requestCode
+    }
+
+    override fun onDismiss(dialog: DialogInterface?) {
+        super.onDismiss(dialog)
+
+        if (mRequestCode == null || mResultCode == null || mTargetFragmentTag == null) return
+
+        val targetFragment = FragmentOperator.findFoFragmentByTag(mTargetFragmentTag!!) ?: return
+
+        targetFragment.onDialogFragmentResult(mRequestCode!!, mResultCode!!, mArguments)
     }
 }

--- a/fragmentoperator/src/main/java/com/tubitv/fragmentoperator/fragment/FoFragment.kt
+++ b/fragmentoperator/src/main/java/com/tubitv/fragmentoperator/fragment/FoFragment.kt
@@ -67,6 +67,12 @@ open class FoFragment : Fragment(), FragmentHost {
         return false
     }
 
+    /**
+     * A method to handle {@link FragmentOperator#showDialogFragmentForResult}.
+     * When the dialog dismissed the result will be passed.
+     */
+    open fun onDialogFragmentResult(requestCode: Int, resultCode: Int, data: Map<String, Any>?) {}
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (savedInstanceState != null) {


### PR DESCRIPTION
Currently, this does not support DialogFragment recreation. If a DialogFragment is recreated by orientation or other reasons, then listeners will be gone.

To handle it, we need to create a function something similar to `startActivityForResult` and `onActivityResult` for DialogFragment.

I `onDialogFragmentResult` method to `FoFragment`, and `showDialogFragmentForResult` to `FragmentOperator`. 